### PR TITLE
minor bugfix in cg.py construct_rest_of_world

### DIFF
--- a/constructive_geometries/cg.py
+++ b/constructive_geometries/cg.py
@@ -107,7 +107,7 @@ class ConstructiveGeometries(object):
             warn(MISSING_GIS)
             return
 
-        geom = _union(included)[1]
+        geom = _union(None, self.faces_fp, included)[1]
         if fp:
             self.write_geoms_to_file(fp, [geom], [name] if name else None)
             return fp


### PR DESCRIPTION
I found a minor bug in `construct_rest_of_world` - thought it'd be useful to flag it